### PR TITLE
[Captcha] Ulozto - fix audio recognition

### DIFF
--- a/module/plugins/captcha/UlozTo.py
+++ b/module/plugins/captcha/UlozTo.py
@@ -29,7 +29,8 @@ class UlozTo(OCR):
                 os.path.split(
                     clslib.__file__)[0],
                 'ulozto.cfg')
-            text = clslib.classify_audio_file(audio, cfg_file)
+            ext_file = os.path.splitext(audio)[1]
+            text = clslib.classify_audio_file(audio, cfg_file, ext_file)
             return text
 
         except NameError:


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` one of the checkboxes below (eg. `[x] Bugfix`).

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

currently  classify_audio_file recognize audio as wav which is wrong type.

### Reasons for making this change:

_OPTIONAL_

### References to this change (related pull requests, issues, etc.):

_OPTIONAL_
